### PR TITLE

Improve the BugTracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,15 +8,16 @@ assignees: ''
 ---
 
 **If this form is left empty, or the relevant sections are left empty, then your issue will be closed without any questions. Further failure to appropriately fill in the sections will result in you being blocked from the Checkra1n BugTracker**
-- [ ] I have already searched this repo for duplicate issues 
-- [ ] I have checked the [frequently asked questions](https://checkra.in)
-- [ ] This issue is producible  on the latest checkra1n version.
+**before you submit an issue, make sure that you have checked the following:**
+
+ *[frequently asked questions](https://checkra.in)
+* This issue is producible  on the latest checkra1n version.
 **Tell us about your setup:**
 1. What iDevice are you using?
 2. On what version of iOS is it?
 3. What version of checkra1n are you using?
 4. What is your host system (MacOS? Linux? Bootable usb?)?
-5. What is it's OS version?
+5. What is its OS version?
 6. How are you connecting to the device (USB-A? USB-C? Apple/3rd party cable? Through a USB hub?)?
 
 **What are the steps to reproduce the issue?**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 **If this form is left empty, or the relevant sections are left empty, then your issue will be closed without any questions. Further failure to appropriately fill in the sections will result in you being blocked from the Checkra1n BugTracker**
-- ( ) I have already searched this repo for duplicate issues 
-- ( ) I have checked the [frequently asked questions](https://checkra.in)
-- ( ) This issue is producible  on the latest checkra1n version.
+- [ ] I have already searched this repo for duplicate issues 
+- [ ] I have checked the [frequently asked questions](https://checkra.in)
+- [ ] This issue is producible  on the latest checkra1n version.
 **Tell us about your setup:**
 1. What iDevice are you using?
 2. On what version of iOS is it?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 **If this form is left empty, or the relevant sections are left empty, then your issue will be closed without any questions. Further failure to appropriately fill in the sections will result in you being blocked from the Checkra1n BugTracker**
- - ( ) I have already searched this repo for duplicate issues 
- - ( ) I have checked the [frequently asked questions](https://checkra.in)
- - ( ) This issue is producible  on the latest checkra1n version.
+- ( ) I have already searched this repo for duplicate issues 
+- ( ) I have checked the [frequently asked questions](https://checkra.in)
+- ( ) This issue is producible  on the latest checkra1n version.
 **Tell us about your setup:**
 1. What iDevice are you using?
 2. On what version of iOS is it?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,12 +7,17 @@ assignees: ''
 
 ---
 
+**If this form is left empty, or the relevant sections are left empty, then your issue will be closed without any questions. Further failure to appropriately fill in the sections will result in you being blocked from the Checkra1n BugTracker**
+ - ( ) I have already searched this repo for duplicate issues 
+ - ( ) I have checked the [frequently asked questions](https://checkra.in)
+ - ( ) This issue is producible  on the latest checkra1n version.
 **Tell us about your setup:**
 1. What iDevice are you using?
 2. On what version of iOS is it?
 3. What version of checkra1n are you using?
-4. What is your host system (OS version? Hackintosh? VM? etc.)?
-5. How are you connecting to the device (USB-A? USB-C? Apple/3rd party cable? Through a USB hub?)?
+4. What is your host system (MacOS? Linux? Bootable usb?)?
+5. What is it's OS version?
+6. How are you connecting to the device (USB-A? USB-C? Apple/3rd party cable? Through a USB hub?)?
 
 **What are the steps to reproduce the issue?**
 1. 


### PR DESCRIPTION
This pull request addresses the following
* To combat the spam on this repo, notify that a person's issue will be first closed and then upon   further violations, the user can be blocked from the BugTracker entirely 
* add tick boxes, which first direct a user to check the frequently asked questions on the checkra1n website and then to check for duplicate issues on this repo
* ask the user if they're on the  latest version of checkra1n 
* refer to host systems as macOS and linux, rather than hackintosh and vm 
